### PR TITLE
Refactor base image repo abstraction 

### DIFF
--- a/app/src/main/java/com/amk/pixalot/domain/repo/BaseImageRepo.kt
+++ b/app/src/main/java/com/amk/pixalot/domain/repo/BaseImageRepo.kt
@@ -3,7 +3,12 @@ package com.amk.pixalot.domain.repo
 import com.amk.pixalot.domain.viewmodel.ImageItem
 import io.reactivex.Observable
 
-interface ImageSourceRepo {
-    fun fetchImages(page: Int = 1): Observable<List<ImageItem>>
-    fun loadMore(): Observable<List<ImageItem>>
+abstract class BaseImageRepo {
+
+    private var currentPage: Int = 1
+
+    abstract fun fetchImages(page: Int = 1): Observable<List<ImageItem>>
+
+    fun loadMore(): Observable<List<ImageItem>> =
+            fetchImages(currentPage.inc()).doOnNext { currentPage = currentPage.inc() }
 }

--- a/app/src/main/java/com/amk/pixalot/domain/repo/PexelRepository.kt
+++ b/app/src/main/java/com/amk/pixalot/domain/repo/PexelRepository.kt
@@ -1,15 +1,12 @@
 package com.amk.pixalot.domain.repo
 
 import com.amk.pixalot.domain.network.pexel.PexelApi
-import com.amk.pixalot.domain.network.unsplash.UnsplashApi
 import com.amk.pixalot.domain.viewmodel.ImageItem
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers.io
 
-open class PexelRepository(private val pexelApi: PexelApi) : ImageSourceRepo {
-
-    private var currentPage: Int = 1
+open class PexelRepository(private val pexelApi: PexelApi) : BaseImageRepo() {
 
     override fun fetchImages(page: Int): Observable<List<ImageItem>> = pexelApi
             .getImages(page = page).map { images ->
@@ -24,8 +21,4 @@ open class PexelRepository(private val pexelApi: PexelApi) : ImageSourceRepo {
             }
             .subscribeOn(io())
             .observeOn(AndroidSchedulers.mainThread())
-
-    override fun loadMore(): Observable<List<ImageItem>> {
-        return fetchImages(currentPage.inc()).doOnNext { currentPage = currentPage.inc() }
-    }
 }

--- a/app/src/main/java/com/amk/pixalot/domain/repo/PixabayRepository.kt
+++ b/app/src/main/java/com/amk/pixalot/domain/repo/PixabayRepository.kt
@@ -6,9 +6,7 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers.io
 
-open class PixabayRepository(private val pixabayApi: PixabayApi) : ImageSourceRepo {
-
-    private var currentPage: Int = 1
+open class PixabayRepository(private val pixabayApi: PixabayApi) : BaseImageRepo() {
 
     override fun fetchImages(page: Int): Observable<List<ImageItem>> = pixabayApi
             .getImages(page = page).map { images ->
@@ -22,8 +20,4 @@ open class PixabayRepository(private val pixabayApi: PixabayApi) : ImageSourceRe
             }
             .subscribeOn(io())
             .observeOn(AndroidSchedulers.mainThread())
-
-    override fun loadMore(): Observable<List<ImageItem>> {
-        return fetchImages(currentPage.inc()).doOnNext { currentPage = currentPage.inc() }
-    }
 }

--- a/app/src/main/java/com/amk/pixalot/domain/repo/UnsplashRepository.kt
+++ b/app/src/main/java/com/amk/pixalot/domain/repo/UnsplashRepository.kt
@@ -6,9 +6,7 @@ import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers.io
 
-open class UnsplashRepository(private val unsplashApi: UnsplashApi) : ImageSourceRepo {
-
-    private var currentPage: Int = 1
+open class UnsplashRepository(private val unsplashApi: UnsplashApi) : BaseImageRepo() {
 
     override fun fetchImages(page: Int): Observable<List<ImageItem>> = unsplashApi
             .getImages(page = page).map { images ->
@@ -23,8 +21,4 @@ open class UnsplashRepository(private val unsplashApi: UnsplashApi) : ImageSourc
             }
             .subscribeOn(io())
             .observeOn(AndroidSchedulers.mainThread())
-
-    override fun loadMore(): Observable<List<ImageItem>> {
-        return fetchImages(currentPage.inc()).doOnNext { currentPage = currentPage.inc() }
-    }
 }

--- a/app/src/main/java/com/amk/pixalot/domain/workflow/PhotoListWorkflow.kt
+++ b/app/src/main/java/com/amk/pixalot/domain/workflow/PhotoListWorkflow.kt
@@ -1,13 +1,13 @@
 package com.amk.pixalot.domain.workflow
 
-import com.amk.pixalot.domain.repo.ImageSourceRepo
+import com.amk.pixalot.domain.repo.BaseImageRepo
 import com.amk.pixalot.domain.store.PhotoListStore
 import com.amk.pixalot.domain.viewmodel.ImageItem
 import com.amk.pixalot.screen.home.photolist.PhotoListViewModel
 import io.reactivex.Observable
 
 open class PhotoListWorkflow(
-        private val repos: List<ImageSourceRepo>,
+        private val repos: List<BaseImageRepo>,
         private val store: PhotoListStore
 ) {
     private fun zipper(data: Array<Any>): List<ImageItem> =
@@ -23,7 +23,7 @@ open class PhotoListWorkflow(
     fun loadMore(): Observable<PhotoListViewModel> = fetchAll({ loadMore() }, { add(it) })
 
     private inline fun fetchAll(
-            fetch: ImageSourceRepo.() -> Observable<List<ImageItem>>,
+            fetch: BaseImageRepo.() -> Observable<List<ImageItem>>,
             crossinline storeOperation: PhotoListStore.(List<ImageItem>) -> PhotoListViewModel
     ): Observable<PhotoListViewModel> {
         return Observable

--- a/app/src/test/java/com/amk/pixalot/domain/workflow/PhotoListWorkflowTest.kt
+++ b/app/src/test/java/com/amk/pixalot/domain/workflow/PhotoListWorkflowTest.kt
@@ -101,6 +101,9 @@ class PhotoListWorkflowTest {
             )
         }
 
+        `when`(pixabayRepo.fetchImages(1)).thenReturn(Observable.just(expectedPixa))
+        `when`(unsplashRepo.fetchImages(1)).thenReturn(Observable.just(expectedUnsplash))
+        `when`(pexelRepo.fetchImages(1)).thenReturn(Observable.just(expectedPexel))
         `when`(pixabayRepo.loadMore()).thenReturn(Observable.just(expectedPixa))
         `when`(unsplashRepo.loadMore()).thenReturn(Observable.just(expectedUnsplash))
         `when`(pexelRepo.loadMore()).thenReturn(Observable.just(expectedPexel))


### PR DESCRIPTION
### CHANGED

- ImageSourceRepo interface into BaseImageRepo abstract class
- provide default load more implementation for easier image source addition

To add new image source we can register new api, then on repository level provide fetch image method to convert network response into ImageItem data class